### PR TITLE
Disable encoding of &, <, > characters in RSF item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea

--- a/serializer.go
+++ b/serializer.go
@@ -67,7 +67,7 @@ func getKey(fieldNames []string, fieldValues []string, registerName string) (str
 }
 
 func processEmptyRootHash() {
-	fmt.Println("assert-root-hash\te3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	fmt.Println("assert-root-hash\tsha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 }
 
 func processLine(fieldValues []string, fieldNames []string, sortedIndexes []int, fieldDefns map[string]Field, registerName string) {

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -26,9 +26,9 @@ func TestBuildJson(t *testing.T) {
 	fieldValues := []string{"d;h", `e "f" g`, "1"}
 	sortedIndexes := []int{2, 1, 0}
 	fields := map[string]Field{
-		"a": Field{"1", "string", "", "", "", ""},
-		"b": Field{"1", "string", "", "", "", ""},
-		"c": Field{"n", "string", "", "", "", ""},
+		"a": {"1", "string", "", "", "", ""},
+		"b": {"1", "string", "", "", "", ""},
+		"c": {"n", "string", "", "", "", ""},
 	}
 	json := buildContentJson(fieldNames, fieldValues, sortedIndexes, fields)
 	expected := `{"a":"1","b":"e \"f\" g","c":["d","h"]}`
@@ -42,9 +42,9 @@ func TestBuildJsonIgnoreWhitespace(t *testing.T) {
 	fieldValues := []string{"d", "  ", "1"}
 	sortedIndexes := []int{2, 1, 0}
 	fields := map[string]Field{
-		"a": Field{"1", "string", "", "", "", ""},
-		"b": Field{"1", "string", "", "", "", ""},
-		"c": Field{"n", "string", "", "", "", ""},
+		"a": {"1", "string", "", "", "", ""},
+		"b": {"1", "string", "", "", "", ""},
+		"c": {"n", "string", "", "", "", ""},
 	}
 	json := buildContentJson(fieldNames, fieldValues, sortedIndexes, fields)
 	expected := `{"a":"1","c":["d"]}`
@@ -167,12 +167,21 @@ func TestMarshalRegister(t *testing.T) {
 	}
 }
 
+func TestEscapedMarshalRegister(t *testing.T) {
+	 reg := Register{"", []string{"address"}, "alpha", "address", "office-for", "Post & address no > no < than that"}
+	 json, _ := toJsonStr(reg)
+	 expected := `{"fields":["address"],"phase":"alpha","register":"address","registry":"office-for","text":"Post & address no > no < than that"}`
+	 if expected != json {
+	 	t.Error(`should write json without escaping &, <, >`)
+	 }
+}
+
 func TestCheckFieldNames(t *testing.T) {
 	fieldNames := []string{"c", "b", "a"}
 	fields := map[string]Field{
-		"a": Field{"1", "string", "", "", "", ""},
-		"b": Field{"1", "string", "", "", "", ""},
-		"c": Field{"n", "string", "", "", "", ""},
+		"a": {"1", "string", "", "", "", ""},
+		"b": {"1", "string", "", "", "", ""},
+		"c": {"n", "string", "", "", "", ""},
 	}
 	if !mapContainsAllKeys(fields, fieldNames) {
 		t.Error("should confirm field names a,b,c all valid")
@@ -182,9 +191,9 @@ func TestCheckFieldNames(t *testing.T) {
 func TestCheckFieldNamesMissing(t *testing.T) {
 	fieldNames := []string{"d", "b", "a"}
 	fields := map[string]Field{
-		"a": Field{"1", "string", "", "", "", ""},
-		"b": Field{"1", "string", "", "", "", ""},
-		"c": Field{"n", "string", "", "", "", ""},
+		"a": {"1", "string", "", "", "", ""},
+		"b": {"1", "string", "", "", "", ""},
+		"c": {"n", "string", "", "", "", ""},
 	}
 	if mapContainsAllKeys(fields, fieldNames) {
 		t.Error("should find not all field names valid")

--- a/utils.go
+++ b/utils.go
@@ -49,8 +49,12 @@ func toJsonArrayOfNum(s string) string {
 }
 
 func toJsonStr(r interface{}) (string, error) {
-	data, err := json.Marshal(r)
-	return string(data), err
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(r)
+
+	return strings.TrimSpace(buf.String()), err
 }
 
 func mapContainsAllKeys(fields map[string]Field, fieldNames []string) bool {
@@ -63,10 +67,10 @@ func mapContainsAllKeys(fields map[string]Field, fieldNames []string) bool {
 }
 
 func stringArrayContains(arr []string, e string) bool {
-    for _, s := range arr {
-        if s == e {
-            return true
-        }
-    }
-    return false
+	for _, s := range arr {
+		if s == e {
+			return true
+		}
+	}
+	return false
 }

--- a/utils.go
+++ b/utils.go
@@ -53,8 +53,7 @@ func toJsonStr(r interface{}) (string, error) {
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	err := enc.Encode(r)
-
-	return strings.TrimSpace(buf.String()), err
+	return strings.TrimSuffix(buf.String(), "\n"), err
 }
 
 func mapContainsAllKeys(fields map[string]Field, fieldNames []string) bool {


### PR DESCRIPTION
https://trello.com/c/Xhq7HJsn/617-serializer-producing-non-canonical-json-containing-escaped-unicode-characters

Those characters were encoded by default (HTML encoding) as some browsers
may have problems with them (explanation from GO lang). We had to switch
that off as RSF generated like that was rejected as it's not canonical
version.

Additionally new implementation of encoder seem to leave some whitespaces
and after looking at stream_test.go where encoders with HTML encoding switched
off are tested we implemented a similar solution which is to trim whitespaces.
This is really terrible on many levels and has ruined our afternoon.