### PR TITLE
Add missing hyphen to sha-256 string for root hash.

### DIFF
--- a/serializer.go
+++ b/serializer.go
@@ -67,7 +67,7 @@ func getKey(fieldNames []string, fieldValues []string, registerName string) (str
 }
 
 func processEmptyRootHash() {
-	fmt.Println("assert-root-hash\tsha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	fmt.Println("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 }
 
 func processLine(fieldValues []string, fieldNames []string, sortedIndexes []int, fieldDefns map[string]Field, registerName string) {


### PR DESCRIPTION
The assert root hash command should contain the hash for an empty item prefixed by sha-256. The hyphen was missing previously.